### PR TITLE
Fix iOS workflow

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.pbxproj -text

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -7,31 +7,50 @@ on:
     branches: [master]
 
 jobs:
-  android:
+  prepare:
     runs-on: macos-latest
-    env:
-      CI: 1
-    strategy:
-      matrix:
-        android-api: [28]
-        android-target: [default]
-        node-version: [12, 14]
-    name: "Matrix: Node v${{ matrix.node-version }}; Android API ${{ matrix.android-api }}"
+    name: "Prepare"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 14
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14
 
       - name: Cache node_modules
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-npm-
+          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: node_modules-
+
+      - name: Install node_modules
+        run: |
+          npm ci --prefer-offline --no-audit
+
+  android:
+    needs: prepare
+    runs-on: macos-latest
+    env:
+      REACT_NATIVE_VERSION: "0.63.4"
+    name: "Android"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Set up Node.js 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        with:
+          path: ~/.npm
+          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: node_modules-
 
       - name: Install node_modules
         run: |
@@ -41,54 +60,60 @@ jobs:
         run: |
           npm run lint
 
-      # - name: Cache Android build
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/.gradle/caches
-      #       ~/.gradle/wrapper
-      #     key: ${{ runner.os }}-gradle-${{ hashFiles('$HOME/.npm/rn-test-app/android/**/*.gradle*') }}-${{ hashFiles('$HOME/.npm/rn-test-app/android/gradle/wrapper/gradle-wrapper.properties') }}
-      #     restore-keys: ${{ runner.os }}-gradle-
+      - name: Cache Android build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/build-cache
+          key: ${{ runner.os }}-gradle-rn-${{ env.REACT_NATIVE_VERSION }}
+
+      - name: Inject test app path into a job-wide environment variable
+        run: |
+          DIR=~/rn-android-test-app
+          echo "REACT_NATIVE_TEST_APP=$DIR" >> $GITHUB_ENV
+
+      - name: Cache React Native test app
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.REACT_NATIVE_TEST_APP }}
+          key: ${{ runner.os }}-rn-android-${{ env.REACT_NATIVE_VERSION }}
 
       - name: Run Android tests
         uses: reactivecircus/android-emulator-runner@v2
         with:
-          api-level: ${{ matrix.android-api }}
-          target: ${{ matrix.android-target }}
+          api-level: 28
+          target: default
           arch: x86_64
           profile: pixel
+          avd-name: google-pixel
           script: |
             npm t -- android
-
-      - name: Submit coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+        env:
+          ANDROID_EMULATOR: google-pixel
 
   ios:
+    needs: prepare
     runs-on: macos-latest
     env:
-      CI: 1
-    strategy:
-      matrix:
-        apple-runtime: ["iOS 14.2"]
-        node-version: [12, 14]
-    name: "Matrix: Node v${{ matrix.node-version }}; ${{ matrix.apple-runtime }}"
+      REACT_NATIVE_VERSION: "0.62.0"
+    name: "iOS"
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
 
-      - name: Set up Node.js ${{ matrix.node-version }}
+      - name: Set up Node.js 14
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14
 
       - name: Cache node_modules
         uses: actions/cache@v2
         with:
           path: ~/.npm
-          key: ${{ runner.os }}-npm-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: ${{ runner.os }}-npm-
+          key: node_modules-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: node_modules-
 
       - name: Install node_modules
         run: |
@@ -98,39 +123,44 @@ jobs:
         run: |
           npm run lint
 
-      # - name: Cache pods and repositories
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: |
-      #       ~/Library/Caches/CocoaPods
-      #       ~/.cocoapods
-      #     key: ${{ runner.os }}-cocoapods-${{ hashFiles('$HOME/.npm/rn-test-app/ios/Podfile.lock') }}
-      #     restore-keys: ${{ runner.os }}-cocoapods-
-
-      # - name: Set up ${{ matrix.apple-runtime }} runtime
+      # - name: List environment capabilities
       #   run: |
-      #     gem install xcode-install
-      #     xcversion simulators --install="${{ matrix.apple-runtime }}"
-
-      - name: List environment capabilities
-        run: |
-          xcversion --version
-          xcodebuild -version
-          xcrun simctl list
+      #     xcversion --version
+      #     xcodebuild -version
+      #     xcrun simctl list
+      #     xcversion select 12.1
 
       - name: Create and run iOS simulator
         run: |
-          SIMULATOR_RUNTIME=$(echo "${{ matrix.apple-runtime }}" | sed 's/[ \.]/-/g')
+          SIMULATOR_RUNTIME=$(echo "iOS 14.4" | sed 's/[ \.]/-/g')
           SIMULATOR_ID=$(xcrun simctl create "iPhone 11" com.apple.CoreSimulator.SimDeviceType.iPhone-11 com.apple.CoreSimulator.SimRuntime.$SIMULATOR_RUNTIME)
           echo "IOS_SIMULATOR=$SIMULATOR_ID" >> $GITHUB_ENV
           xcrun simctl boot $SIMULATOR_ID &
 
-      # - name: Cache iOS build
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: ~/Library/Developer/Xcode/DerivedData/Test-*
-      #     key: ${{ runner.os }}-xcodebuild-${{ hashFiles('$HOME/.npm/rn-test-app/ios/Test*/**') }}
-      #     restore-keys: ${{ runner.os }}-xcodebuild-
+      - name: Cache iOS build
+        uses: actions/cache@v2
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData/Test-*
+          key: ${{ runner.os }}-xcodebuild-rn-${{ env.REACT_NATIVE_VERSION }}
+
+      - name: Cache pods and repositories
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/Library/Caches/CocoaPods
+            ~/.cocoapods
+          key: ${{ runner.os }}-cocoapods-rn-${{ env.REACT_NATIVE_VERSION }}
+
+      - name: Inject test app path into a job-wide environment variable
+        run: |
+          DIR=~/rn-ios-test-app
+          echo "REACT_NATIVE_TEST_APP=$DIR" >> $GITHUB_ENV
+
+      - name: Cache React Native test app
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.REACT_NATIVE_TEST_APP }}
+          key: ${{ runner.os }}-rn-ios-${{ env.REACT_NATIVE_VERSION }}
 
       - name: Run iOS tests
         run: |
@@ -139,8 +169,3 @@ jobs:
       - name: Shutdown iOS simulator
         run: |
           xcrun simctl shutdown $IOS_SIMULATOR
-
-      - name: Submit coverage
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,13 +1,11 @@
 # react-native-test-runner
 
-[![npm version][npm-image]][npm-url] [![ci][github-ci-image]][github-ci-url] [![codecov][codecov-image]][codecov-url]
+[![npm version][npm-image]][npm-url] [![ci][github-ci-image]][github-ci-url]
 
 [npm-url]:https://www.npmjs.com/package/react-native-test-runner
 [npm-image]:https://img.shields.io/npm/v/react-native-test-runner.svg
 [github-ci-url]:https://github.com/acostalima/react-native-test-runner/actions
 [github-ci-image]:https://github.com/acostalima/react-native-test-runner/workflows/Node%20CI/badge.svg
-[codecov-url]:https://codecov.io/gh/acostalima/react-native-test-runner?branch=master
-[codecov-image]:https://codecov.io/gh/acostalima/react-native-test-runner/badge.svg?branch=master
 
 > Run tests in React Native's environment.
 
@@ -32,9 +30,9 @@ $ npm install -D react-native-test-runner
 ## Limitations
 
 - No coverage output.
-- No support for Windows and macOS.
+- No support for [React Native Windows](https://github.com/microsoft/react-native-windows) and [React Native macOS](https://github.com/microsoft/react-native-macos).
 - JavaScriptCore (JSC) engine only on both Android and iOS.
-- No TypeScript (TS) support yet.
+- No TypeScript (TS) support.
 
 ## Usage
 
@@ -48,12 +46,12 @@ Options
     --plaform, -p          Platform on which to run the test suite on. One of: 'ios', 'android'.
     --simulator, -s        iOS simulator to run the test suite on.
     --emulator, -e         Android emulator or virtual device (AVD) to run the test suite on.
-    --metroPort, -p        Port on which Metro's server should listen to. [Default: 8081]
+    --metro-port, -p        Port on which Metro's server should listen to. [Default: 8081]
     --cwd                  Current directory. [Default: process.cwd()]
     --rn                   React Native version to use. [Default: 0.63.4]
     --runner               Test runner to use. One of: 'zora', 'mocha'. [Default: 'zora']
     --require              Path to the module to load before the test suite. If not absolute, cwd is used to resolve the path.
-    --removeTestApp        Removes the native test app directory after running the test suite. [Default: false]
+    --app                  Path to the React Native test app root. [Default: ~/.rn-test-app]
 
 Examples
     # Run tests on iPhone 11 simulator with iOS version 14.1 runtime
@@ -101,7 +99,7 @@ $ rn-test 'test/**/*.test.js'
 
 Type: `array`
 
-Install packages in the test app. This is mostly useful when you are testing modules that have a native iOS and/or Android component or the code under test depends on them.
+Install packages in the test app. This is mostly useful when you are using modules that have a native iOS and/or Android component or the code under test depends on them.
 
 Example:
 
@@ -139,9 +137,52 @@ module.exports = {
 }
 ```
 
+## Tests
+
+This section is about how you can run the test suite locally.
+
+### Environment setup
+
+The test suite can be parameterized with the following environment variables:
+
+| Variable | CLI option | Default |
+|----------|------------|---------|
+| `REACT_NATIVE_VERSION` | `rn` | CLI default |
+| `REACT_NATIVE_TEST_APP` | `app` | CLI default |
+| `IOS_SIMULATOR` | `simulator` | `'iPhone (14.1)'` |
+| `ANDROID_SIMULATOR`| `emulator` | `'Pixel_API_28_AOSP'` |
+
+Both `IOS_SIMULATOR` and `ANDROID_EMULATOR` must be set according to what iOS simulators and Android emulators you have installed in your system.
+
+You can find the list of iOS simulators available in your system by running the following command:
+
+```
+$ xcrun xctrace list devices
+```
+
+For the list of Android emulators, run:
+
+```
+$ emulator -list-avds
+```
+
+### Run on iOS
+
+⚠️ A machine with macOS operating system is required!
+
+```
+$ npm t -- ios
+```
+
+### Run on Android
+
+```
+$ npm t -- android
+```
+
 ## Known issues
 
-- `metroPort` option does not work on iOS. While Metro does listen to the specified port, the app, as a client, still attempts to load the bundle from port 8081. See https://github.com/facebook/react-native/issues/9145.
+- While `metroPort` works in [Android](https://github.com/facebook/react-native/pull/23616), it doesn't on [iOS](https://github.com/facebook/react-native/issues/9145). Metro does listen to the specified port but, the app, as a client, still attempts to load the bundle from port 8081.
 ## License
 
 MIT © [André Costa Lima](https://github.com/acostalima)

--- a/cli/create-test-app.js
+++ b/cli/create-test-app.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const path = require('path');
-const os = require('os');
 const { promisify } = require('util');
 const fs = require('fs-extra');
 const tempy = require('tempy');
@@ -53,7 +52,7 @@ const applyPatches = (loader, testAppRoot, patches) => {
 
 module.exports = async ({
     rn: reactNativeVersion = '0.63.4',
-    testAppRoot = path.join(os.homedir(), '.npm', 'rn-test-app'),
+    app: testAppRoot,
     modules = [],
     patches = [],
 } = {}) => {
@@ -89,12 +88,12 @@ module.exports = async ({
         await installModules(loader, testAppRoot, modulesToInstall);
         await applyPatches(loader, testAppRoot, patches);
 
-        return { testAppRoot, removeTestApp };
+        return { removeTestApp };
     }
 
     try {
         await tempy.directory.task(async (reactNativeCliPkgPath) => {
-            loader.start(`Initializing npm package for React Native CLI at ${reactNativeCliPkgPath}`);
+            loader.start(`Initializing React Native CLI at ${reactNativeCliPkgPath}`);
             await execa('npm', ['init', '-y'], { cwd: reactNativeCliPkgPath });
             loader.succeed();
 
@@ -119,5 +118,5 @@ module.exports = async ({
         throw error;
     }
 
-    return { testAppRoot, removeTestApp };
+    return { removeTestApp };
 };

--- a/cli/run-android.js
+++ b/cli/run-android.js
@@ -1,5 +1,4 @@
-// Inspired by and adapted from:
-// - https://github.com/react-native-community/cli/tree/master/packages/platform-android/src/commands/runAndroid
+// Inspired by and adapted from: https://github.com/react-native-community/cli/tree/master/packages/platform-android/src/commands/runAndroid
 
 'use strict';
 

--- a/cli/run-ios.js
+++ b/cli/run-ios.js
@@ -1,5 +1,4 @@
-// Inspired by and adapted from:
-// - https://github.com/react-native-community/cli/blob/master/packages/platform-ios/src/commands/runIOS
+// Inspired by and adapted from: https://github.com/react-native-community/cli/blob/master/packages/platform-ios/src/commands/runIOS
 
 'use strict';
 

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -1,3 +1,3 @@
 'use strict';
 
-jest.setTimeout(15 * 60 * 1000); // 15 mins
+jest.setTimeout(30 * 60 * 1000); // 15 mins

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "android"
   ],
   "engines": {
-    "node": ">=12"
+    "node": ">=14"
   },
   "bin": {
     "rn-test": "./cli/index.js"

--- a/test/utils/create-cli.js
+++ b/test/utils/create-cli.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const execa = require('execa');
+
+const {
+    REACT_NATIVE_VERSION,
+    REACT_NATIVE_TEST_APP,
+    ANDROID_EMULATOR = 'Pixel_API_28_AOSP',
+    IOS_SIMULATOR = 'iPhone 11 (14.1)',
+} = process.env;
+
+const createCli = (testFileGlobs = [], options) => {
+    const args = new Map();
+
+    if (!Array.isArray(testFileGlobs)) {
+        testFileGlobs = [testFileGlobs];
+    }
+
+    const cli = {
+        runner(runner) {
+            args.set('--runner', runner);
+
+            return this;
+        },
+        require(script) {
+            args.set('--require', script);
+
+            return this;
+        },
+        platform(platform) {
+            args.set('--platform', platform);
+
+            return this;
+        },
+        rn(rn = REACT_NATIVE_VERSION) {
+            if (rn) {
+                args.set('--rn', rn);
+            }
+
+            return this;
+        },
+        app(app = REACT_NATIVE_TEST_APP) {
+            if (app) {
+                args.set('--app', app);
+            }
+
+            return this;
+        },
+        config(config) {
+            args.set('--config', config);
+
+            return this;
+        },
+        run(moreArgs = []) {
+            return execa(
+                './cli/index.js',
+                [
+                    ...Array.from(args, ([argName, argValue]) => [argName, argValue]).flat(),
+                    ...moreArgs,
+                    ...testFileGlobs,
+                ],
+                options,
+            );
+        },
+    };
+
+    cli.app();
+    cli.rn();
+
+    return cli;
+};
+
+const createIOSCli = (testFileGlobs, options) => {
+    const cli = createCli(testFileGlobs, options).platform('ios');
+
+    return {
+        ...cli,
+        run(moreArgs = []) {
+            return cli.run(['--simulator', IOS_SIMULATOR, ...moreArgs]);
+        },
+    };
+};
+
+const createAndroidCli = (testFileGlobs, options) => {
+    const cli = createCli(testFileGlobs, options).platform('android');
+
+    return {
+        ...cli,
+        run(moreArgs = []) {
+            return cli.run(['--emulator', ANDROID_EMULATOR, ...moreArgs]);
+        },
+    };
+};
+
+exports.createAndroidCli = createAndroidCli;
+exports.createIOSCli = createIOSCli;
+


### PR DESCRIPTION
Fixes #11
Fixes #16

### Additional changes

- Added cache to Android build.
- Added cache to iOS build.
- Removed code coverage badge and actions from the CI workflow.
- Removed the CLI switch which would delete the test app directory after running the test suite.
- Added CLI switch which to specify the path where the test app should be installed in.
- Renamed `configFile` CLI switch to just `config`. 
- Created a CLI factory test util.
- Clarified the limitations in the README concerning native platform support. 
- Add section about how to run the test suite locally.